### PR TITLE
Install matlab files in private dir

### DIFF
--- a/pymatbridge/version.py
+++ b/pymatbridge/version.py
@@ -86,5 +86,5 @@ MINOR = _version_minor
 MICRO = _version_micro
 VERSION = __version__
 PACKAGES = ['pymatbridge']
-PACKAGE_DATA = {"pymatbridge": ["matlab/*.m", "matlab/functions/*.m", "matlab/www/*.m", "test/*.m", "test/*.py"]}
+PACKAGE_DATA = {"pymatbridge": ["matlab/*.m", "matlab/functions/*.m", "matlab/private/*.m", "matlab/www/*.m", "test/*.m", "test/*.py"]}
 REQUIRES = []


### PR DESCRIPTION
I just tried to install pymatlab bridge. It seems like this dir is needed and not installed. 
