### PR TITLE
escape \ in matlab strings

### DIFF
--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -187,6 +187,8 @@ class Matlab(object):
         # Deal with escape characters: json needs an additional '\':
         # Kill backspaces (why does Matlab even put these there!?): 
         read_page = read_page.replace("\x08", "")
+        # Matlab strings containing \ like dirs on windows:
+        read_page = read_page.replace("\\", "\\\\")
         # Keep new-lines:
         read_page = read_page.replace("\n","\\n")
         return json.loads(read_page)


### PR DESCRIPTION
I tried running some matlab code in a Matlab cell magic, the code contains
a string like "test\" and the magic fails with a json error since this is not properly escaped.
This seems like the simplest solution that resolves the problem but I did not carefully test it
in other situations. 
