### PR TITLE
import numpy

### DIFF
--- a/pymatbridge/examples/pymatbridge.ipynb
+++ b/pymatbridge/examples/pymatbridge.ipynb
@@ -12,6 +12,7 @@
      "collapsed": false,
      "input": [
       "import os\n",
+      "import numpy as np\n",
       "import pymatbridge as pymat\n",
       "reload(pymat)"
      ],


### PR DESCRIPTION
pymatbridge.ipynb calls np.array, but it's not imported
