### PR TITLE
Add --silent option for text output in magic

### DIFF
--- a/pymatbridge/matlab_magic.py
+++ b/pymatbridge/matlab_magic.py
@@ -146,6 +146,11 @@ class MatlabMagics(Magics):
         )
 
     @argument(
+        '-s', '--silent', action='store_true',
+        help='Do not display text output of MATLAB command'
+        )
+
+    @argument(
         'code',
         nargs='*',
         )
@@ -219,7 +224,7 @@ class MatlabMagics(Magics):
         data_dir = result_dict['content']['datadir']
 
         display_data = []
-        if text_output:
+        if text_output and not args.silent:
             display_data.append(('MatlabMagic.matlab',
                                  {'text/plain':text_output}))
 


### PR DESCRIPTION
Sometimes MATLAB functions print quite a bit of text to stdout. This
flag prevents this from being rendered in the Notebook.

In this example, the output from forgetting semicolons will not be
displayed:

```
%%matlab --silent -o x
a = [1, 2, 3]
x = a * 3
```
