### PR TITLE
Remove numpy use from pymatbridge.py.

### DIFF
--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -9,7 +9,6 @@ Part of Python-MATLAB-bridge, Max Jaderberg 2012
 This is a modified version using ZMQ, Haoxing Zhang Jan.2014
 """
 
-import numpy as np
 import os, time
 import zmq
 import subprocess
@@ -171,7 +170,7 @@ class Matlab(object):
                 else:
                     return False
             except zmq.ZMQError:
-                np.disp(".", linefeed=False)
+                sys.stdout.write('.')
                 time.sleep(1)
                 if (time.time() - start_time > self.maxtime) :
                     print "Matlab session timed out after %d seconds" % (self.maxtime)


### PR DESCRIPTION
This is the only use of numpy in this file, and it just writes a dot to stdout. This change would let me use this library without needing to install numpy, since I'm using it on its own, outside of ipython, and so only depend on this module.
