### PR TITLE
Fix json paths in version.py

### DIFF
--- a/pymatbridge/version.py
+++ b/pymatbridge/version.py
@@ -91,8 +91,8 @@ PACKAGE_DATA = {"pymatbridge": ["matlab/matlabserver.m", "matlab/messenger.*",
                                 "matlab/util/json_v0.2.2/LICENSE",
                                 "matlab/util/json_v0.2.2/README.md",
                                 "matlab/util/json_v0.2.2/test/*",
-                                "matlab/util/json_v0.2.2/+json/*.m",
-                                "matlab/util/json_v0.2.2/+json/java/*",
+                                "matlab/util/json_v0.2.2/json/*.m",
+                                "matlab/util/json_v0.2.2/json/java/*",
                                 "tests/*.py", "examples/*.ipynb"]}
 
 REQUIRES = []


### PR DESCRIPTION
I missed this in my PR -- it works locally because the `matlab/` directory is added to the path, but I tried installing from master with pip and it didn't work because the json functions weren't included. My bad!
