### PR TITLE
Make codebase python3 compatible.

### DIFF
--- a/pymatbridge/compat.py
+++ b/pymatbridge/compat.py
@@ -1,0 +1,10 @@
+import sys
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+    unichr = chr
+else:
+    text_type = unicode
+    unichr = unichr

--- a/pymatbridge/matlab_magic.py
+++ b/pymatbridge/matlab_magic.py
@@ -17,7 +17,6 @@ import tempfile
 from glob import glob
 from shutil import rmtree
 from getopt import getopt
-from urllib2 import URLError
 
 import numpy as np
 try:
@@ -37,6 +36,7 @@ from IPython.core.magic_arguments import (argument, magic_arguments,
 from IPython.utils.py3compat import str_to_unicode, unicode_to_str, PY3
 
 import pymatbridge as pymat
+from .compat import text_type
 
 
 class MatlabInterperterError(RuntimeError):
@@ -56,7 +56,7 @@ class MatlabInterperterError(RuntimeError):
         __str__ = __unicode__
     else:
         def __str__(self):
-            return unicode_to_str(unicode(self), 'utf-8')
+            return unicode_to_str(text_type(self), 'utf-8')
 
 
 
@@ -210,7 +210,7 @@ class MatlabMagics(Magics):
             else:
                 e_s = "There was an error running the code:\n %s"%code
                 result_dict = self.eval(code)
-        except URLError:
+        except:
             e_s += "\n-----------------------"
             e_s += "\nAre you sure Matlab is started?"
             raise RuntimeError(e_s)

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -114,8 +114,8 @@ class _Session(object):
     # Start server/client session and make the connection
     def start(self):
         # Start the MATLAB server in a new process
-        print "Starting %s on ZMQ socket %s" % (self._program_name(), self.socket_addr)
-        print "Send 'exit' command to kill the server"
+        print("Starting %s on ZMQ socket %s" % (self._program_name(), self.socket_addr))
+        print("Send 'exit' command to kill the server")
         self._run_server()
 
         # Start the client
@@ -127,15 +127,15 @@ class _Session(object):
 
         # Test if connection is established
         if self.is_connected():
-            print "%s started and connected!" % self._program_name()
+            print("%s started and connected!" % self._program_name())
             return True
         else:
-            print "%s failed to start" % self._program_name()
+            print("%s failed to start" % self._program_name())
             return False
 
     def _response(self, **kwargs):
         req = json.dumps(kwargs, cls=ComplexEncoder)
-        self.socket.send(req)
+        self.socket.send_string(req)
         resp = self.socket.recv_string()
         return resp
 
@@ -143,7 +143,7 @@ class _Session(object):
     def stop(self):
         # Matlab should respond with "exit" if successful
         if self._response(cmd='exit') == "exit":
-            print "%s closed" % self._program_name()
+            print("%s closed" % self._program_name())
 
         self.started = False
         return True
@@ -155,7 +155,7 @@ class _Session(object):
             return False
 
         req = json.dumps(dict(cmd="connect"), cls=ComplexEncoder)
-        self.socket.send(req)
+        self.socket.send_string(req)
 
         start_time = time.time()
         while True:
@@ -166,7 +166,7 @@ class _Session(object):
                 sys.stdout.write('.')
                 time.sleep(1)
                 if time.time() - start_time > self.maxtime:
-                    print "%s session timed out after %d seconds" % (self._program_name(), self.maxtime)
+                    print("%s session timed out after %d seconds" % (self._program_name(), self.maxtime))
                     return False
 
     def is_function_processor_working(self):

--- a/pymatbridge/tests/test_json.py
+++ b/pymatbridge/tests/test_json.py
@@ -1,4 +1,5 @@
 import pymatbridge as pymat
+from pymatbridge.compat import unichr
 import numpy.testing as npt
 import test_utils as tu
 

--- a/pymatbridge/tests/test_run_code.py
+++ b/pymatbridge/tests/test_run_code.py
@@ -1,4 +1,5 @@
 import pymatbridge as pymat
+from pymatbridge.compat import text_type
 import numpy.testing as npt
 import test_utils as tu
 
@@ -38,19 +39,19 @@ class TestRunCode:
         result_division = self.mlab.run_code("c = a / b")['content']['stdout']
 
         if tu.on_octave():
-            npt.assert_equal(result_assignment_a, unicode("a =  21.235\n"))
-            npt.assert_equal(result_assignment_b, unicode("b =  347.75\n"))
-            npt.assert_equal(result_sum, unicode("ans =  368.98\n"))
-            npt.assert_equal(result_diff, unicode("ans = -326.51\n"))
-            npt.assert_equal(result_product, unicode("ans =  7384.2\n"))
-            npt.assert_equal(result_division, unicode("c =  0.061063\n"))
+            npt.assert_equal(result_assignment_a, text_type("a =  21.235\n"))
+            npt.assert_equal(result_assignment_b, text_type("b =  347.75\n"))
+            npt.assert_equal(result_sum, text_type("ans =  368.98\n"))
+            npt.assert_equal(result_diff, text_type("ans = -326.51\n"))
+            npt.assert_equal(result_product, text_type("ans =  7384.2\n"))
+            npt.assert_equal(result_division, text_type("c =  0.061063\n"))
         else:
-            npt.assert_equal(result_assignment_a, unicode("\na =\n\n   21.2345\n\n"))
-            npt.assert_equal(result_assignment_b, unicode("\nb =\n\n  347.7450\n\n"))
-            npt.assert_equal(result_sum, unicode("\nans =\n\n  368.9795\n\n"))
-            npt.assert_equal(result_diff, unicode("\nans =\n\n -326.5105\n\n"))
-            npt.assert_equal(result_product, unicode("\nans =\n\n   7.3842e+03\n\n"))
-            npt.assert_equal(result_division, unicode("\nc =\n\n    0.0611\n\n"))
+            npt.assert_equal(result_assignment_a, text_type("\na =\n\n   21.2345\n\n"))
+            npt.assert_equal(result_assignment_b, text_type("\nb =\n\n  347.7450\n\n"))
+            npt.assert_equal(result_sum, text_type("\nans =\n\n  368.9795\n\n"))
+            npt.assert_equal(result_diff, text_type("\nans =\n\n -326.5105\n\n"))
+            npt.assert_equal(result_product, text_type("\nans =\n\n   7.3842e+03\n\n"))
+            npt.assert_equal(result_division, text_type("\nc =\n\n    0.0611\n\n"))
 
     # Put in some undefined code
     def test_undefined_code(self):


### PR DESCRIPTION
This should address #51.

These are the changes:
- Replaced `print` statements with calls to `print` function.
- For pyzmq, call `send_string` instead of `send`. More info here: http://zeromq.github.io/pyzmq/unicode.html
- Instead of referring to `unicode` and `unichr`, add a `compat.py` module that defines them appropriately based on python version. Could use [six](https://pythonhosted.org/six/) here, but since it was just these two things I didn't think it was worth the extra dependency.
- Finally, in one place there was an exception handler for `urllib2.URLError`, which doesn't exist in python3. I couldn't figure out the code path that throws this exception -- I tried running code on a non-started `Matlab` instance, and also starting a `Matlab` instance and killing the process manually, but neither triggered it. It was added in 79d2025a4ff173639acff3f02e634abc0b860ba4 -- maybe you remember what causes it? In the meantime I've replaced it with a bare `except`, which is not great.

I ran the tests with python 2.7.8 and python 3.4.1 and they all passed in both cases. Let me know if this looks fine.
