### PR TITLE
Make get_variable return None if the var doesn't exist in the workspace.

### DIFF
--- a/pymatbridge/matlab/util/pymat_get_variable.m
+++ b/pymatbridge/matlab/util/pymat_get_variable.m
@@ -24,7 +24,17 @@ end
 
 varname = req.varname;
 
-response.var = evalin('base', varname);
+
+% if the var doesn't exist in the workspace, inform adequately
+expr = strcat('exist(''', varname, ''',''var'')');
+var_exists = evalin('base', expr);
+if ~var_exists;
+    response.exists = false;
+    response.var = '';
+else
+    response.exists = true;
+    response.var = evalin('base', varname);
+end
 
 json_response = json_dump(response);
 

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -208,8 +208,12 @@ class _Session(object):
     def run_code(self, code):
         return self._json_response(cmd='run_code', code=code)
 
-    def get_variable(self, varname):
-        return self._json_response(cmd='get_var', varname=varname)['var']
+    def get_variable(self, varname, default=None):
+        response = self._json_response(cmd='get_var', varname=varname)
+        if response['exists']:
+            return response['var']
+        else:
+            return default
 
     def set_variable(self, varname, value):
         if isinstance(value, spmatrix):

--- a/pymatbridge/tests/test_get_variable.py
+++ b/pymatbridge/tests/test_get_variable.py
@@ -35,8 +35,14 @@ class TestGetVariable:
 
 
     # Try to get a non-existent variable
-    # This one will always fail now since the matlab function cannot handle this situation
-#    def test_nonexistent_var(self):
-#        self.mlab.run_code("clear")
+    def test_nonexistent_var(self):
+        self.mlab.run_code("clear")
 
-#        npt.assert_equal(self.mlab.get_variable('a'), unicode("456345.3453"))
+        npt.assert_equal(self.mlab.get_variable('a'), None)
+
+
+    # Try to get a non-existent variable with default
+    def test_nonexistent_var_default(self):
+        self.mlab.run_code("clear")
+
+        npt.assert_equal(self.mlab.get_variable('a', 'some_val'), 'some_val')


### PR DESCRIPTION
This fixes bug #91 .
