### PR TITLE
Efficient Array Passing

### DIFF
--- a/pymatbridge/matlab/util/json_v0.2.2/json/json_dump.m
+++ b/pymatbridge/matlab/util/json_v0.2.2/json/json_dump.m
@@ -63,7 +63,6 @@ function str = json_dump(value, varargin)
 % mapped to the same json string '[1,2]'.
 %
 % See also json.load json.write
-
   json_startup('WarnOnAddpath', true);
   options = get_options_(varargin{:});
   obj = dump_data_(value, options);
@@ -102,7 +101,14 @@ function obj = dump_data_(value, options)
   elseif ~isscalar(value)
     obj = javaObject('org.json.JSONArray');
 
-    if ndims(value) > 2
+    if strcmp(class(value), 'double')
+        % encode double arrays as a struct
+        double_struct = struct;
+        double_struct.ndarray = 1;
+        double_struct.data = base64encode(typecast(value(:), 'uint8'));
+        double_struct.shape = base64encode(typecast(size(value), 'uint8'));
+        obj = dump_data_(double_struct, options);
+    elseif ndims(value) > 2
       split_value = num2cell(value, 1:ndims(value)-1);
       for i = 1:numel(split_value)
         obj.put(dump_data_(split_value{i}, options));
@@ -150,4 +156,166 @@ function obj = dump_data_(value, options)
   else
     error('json:typeError', 'Unsupported data type: %s', class(value));
   end
+end
+
+
+function y = base64encode(x, eol)
+%BASE64ENCODE Perform base64 encoding on a string.
+%
+%   BASE64ENCODE(STR, EOL) encode the given string STR.  EOL is the line ending
+%   sequence to use; it is optional and defaults to '\n' (ASCII decimal 10).
+%   The returned encoded string is broken into lines of no more than 76
+%   characters each, and each line will end with EOL unless it is empty.  Let
+%   EOL be empty if you do not want the encoded string broken into lines.
+%
+%   STR and EOL don't have to be strings (i.e., char arrays).  The only
+%   requirement is that they are vectors containing values in the range 0-255.
+%
+%   This function may be used to encode strings into the Base64 encoding
+%   specified in RFC 2045 - MIME (Multipurpose Internet Mail Extensions).  The
+%   Base64 encoding is designed to represent arbitrary sequences of octets in a
+%   form that need not be humanly readable.  A 65-character subset
+%   ([A-Za-z0-9+/=]) of US-ASCII is used, enabling 6 bits to be represented per
+%   printable character.
+%
+%   Examples
+%   --------
+%
+%   If you want to encode a large file, you should encode it in chunks that are
+%   a multiple of 57 bytes.  This ensures that the base64 lines line up and
+%   that you do not end up with padding in the middle.  57 bytes of data fills
+%   one complete base64 line (76 == 57*4/3):
+%
+%   If ifid and ofid are two file identifiers opened for reading and writing,
+%   respectively, then you can base64 encode the data with
+%
+%      while ~feof(ifid)
+%         fwrite(ofid, base64encode(fread(ifid, 60*57)));
+%      end
+%
+%   or, if you have enough memory,
+%
+%      fwrite(ofid, base64encode(fread(ifid)));
+%
+%   See also BASE64DECODE.
+
+%   Author:      Peter J. Acklam
+%   Time-stamp:  2004-02-03 21:36:56 +0100
+%   E-mail:      pjacklam@online.no
+%   URL:         http://home.online.no/~pjacklam
+
+   % check number of input arguments
+   error(nargchk(1, 2, nargin));
+
+   % make sure we have the EOL value
+   if nargin < 2
+      eol = ''; %sprintf('\n');
+   else
+      if sum(size(eol) > 1) > 1
+         error('EOL must be a vector.');
+      end
+      if any(eol(:) > 255)
+         error('EOL can not contain values larger than 255.');
+      end
+   end
+
+   if sum(size(x) > 1) > 1
+      error('STR must be a vector.');
+   end
+
+   x   = uint8(x);
+   eol = uint8(eol);
+
+   ndbytes = length(x);                 % number of decoded bytes
+   nchunks = ceil(ndbytes / 3);         % number of chunks/groups
+   nebytes = 4 * nchunks;               % number of encoded bytes
+
+   % add padding if necessary, to make the length of x a multiple of 3
+   if rem(ndbytes, 3)
+      x(end+1 : 3*nchunks) = 0;
+   end
+
+   x = reshape(x, [3, nchunks]);        % reshape the data
+   y = repmat(uint8(0), 4, nchunks);    % for the encoded data
+
+   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+   % Split up every 3 bytes into 4 pieces
+   %
+   %    aaaaaabb bbbbcccc ccdddddd
+   %
+   % to form
+   %
+   %    00aaaaaa 00bbbbbb 00cccccc 00dddddd
+   %
+   y(1,:) = bitshift(x(1,:), -2);                  % 6 highest bits of x(1,:)
+
+   y(2,:) = bitshift(bitand(x(1,:), 3), 4);        % 2 lowest bits of x(1,:)
+   y(2,:) = bitor(y(2,:), bitshift(x(2,:), -4));   % 4 highest bits of x(2,:)
+
+   y(3,:) = bitshift(bitand(x(2,:), 15), 2);       % 4 lowest bits of x(2,:)
+   y(3,:) = bitor(y(3,:), bitshift(x(3,:), -6));   % 2 highest bits of x(3,:)
+
+   y(4,:) = bitand(x(3,:), 63);                    % 6 lowest bits of x(3,:)
+
+   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+   % Now perform the following mapping
+   %
+   %   0  - 25  ->  A-Z
+   %   26 - 51  ->  a-z
+   %   52 - 61  ->  0-9
+   %   62       ->  +
+   %   63       ->  /
+   %
+   % We could use a mapping vector like
+   %
+   %   ['A':'Z', 'a':'z', '0':'9', '+/']
+   %
+   % but that would require an index vector of class double.
+   %
+   z = repmat(uint8(0), size(y));
+   i =           y <= 25;  z(i) = 'A'      + double(y(i));
+   i = 26 <= y & y <= 51;  z(i) = 'a' - 26 + double(y(i));
+   i = 52 <= y & y <= 61;  z(i) = '0' - 52 + double(y(i));
+   i =           y == 62;  z(i) = '+';
+   i =           y == 63;  z(i) = '/';
+   y = z;
+
+   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+   % Add padding if necessary.
+   %
+   npbytes = 3 * nchunks - ndbytes;     % number of padding bytes
+   if npbytes
+      y(end-npbytes+1 : end) = '=';     % '=' is used for padding
+   end
+
+   if isempty(eol)
+
+      % reshape to a row vector
+      y = reshape(y, [1, nebytes]);
+
+   else
+
+      nlines = ceil(nebytes / 76);      % number of lines
+      neolbytes = length(eol);          % number of bytes in eol string
+
+      % pad data so it becomes a multiple of 76 elements
+      y(nebytes + 1 : 76 * nlines) = 0;
+      y = reshape(y, 76, nlines);
+
+      % insert eol strings
+      eol = eol(:);
+      y(end + 1 : end + neolbytes, :) = eol(:, ones(1, nlines));
+
+      % remove padding, but keep the last eol string
+      m = nebytes + neolbytes * (nlines - 1);
+      n = (76+neolbytes)*nlines - neolbytes;
+      y(m+1 : n) = '';
+
+      % extract and reshape to row vector
+      y = reshape(y, 1, m+neolbytes);
+
+   end
+
+   % output is a character array
+   y = char(y);
 end

--- a/pymatbridge/matlab/util/json_v0.2.2/json/json_dump.m
+++ b/pymatbridge/matlab/util/json_v0.2.2/json/json_dump.m
@@ -101,12 +101,17 @@ function obj = dump_data_(value, options)
   elseif ~isscalar(value)
     obj = javaObject('org.json.JSONArray');
 
-    if isnumeric(value) && isreal(value)
+    if isnumeric(value)
         % encode arrays as a struct
         double_struct = struct;
         double_struct.ndarray = 1;
         value = double(value);
-        double_struct.data = base64encode(typecast(value(:), 'uint8'));
+        if isreal(value) 
+          double_struct.data = base64encode(typecast(value(:), 'uint8'));
+        else
+          double_struct.real = base64encode(typecast(real(value(:)), 'uint8'));
+          double_struct.imag = base64encode(typecast(imag(value(:)), 'uint8'));
+        end
         double_struct.shape = base64encode(typecast(size(value), 'uint8'));
         obj = dump_data_(double_struct, options);
     elseif ndims(value) > 2

--- a/pymatbridge/matlab/util/json_v0.2.2/json/json_dump.m
+++ b/pymatbridge/matlab/util/json_v0.2.2/json/json_dump.m
@@ -101,7 +101,7 @@ function obj = dump_data_(value, options)
   elseif ~isscalar(value)
     obj = javaObject('org.json.JSONArray');
 
-    if strcmp(class(value), 'double')
+    if strcmp(class(value), 'double') && ~iscell(value)
         % encode double arrays as a struct
         double_struct = struct;
         double_struct.ndarray = 1;

--- a/pymatbridge/matlab/util/json_v0.2.2/json/json_dump.m
+++ b/pymatbridge/matlab/util/json_v0.2.2/json/json_dump.m
@@ -101,10 +101,11 @@ function obj = dump_data_(value, options)
   elseif ~isscalar(value)
     obj = javaObject('org.json.JSONArray');
 
-    if strcmp(class(value), 'double') && ~iscell(value)
-        % encode double arrays as a struct
+    if isnumeric(value) && isreal(value)
+        % encode arrays as a struct
         double_struct = struct;
         double_struct.ndarray = 1;
+        value = double(value);
         double_struct.data = base64encode(typecast(value(:), 'uint8'));
         double_struct.shape = base64encode(typecast(size(value), 'uint8'));
         obj = dump_data_(double_struct, options);

--- a/pymatbridge/matlab/util/json_v0.2.2/json/json_load.m
+++ b/pymatbridge/matlab/util/json_v0.2.2/json/json_load.m
@@ -129,9 +129,8 @@ function value = parse_data_(node, options)
     end
     % Check if the struct just decoded represents a numpy array
     if isfield(value,'ndarray') && isfield(value, 'shape')
-      disp(value.shape)
       arr = typecast(base64decode(value.data), 'double');
-      value = arr;  %reshape(arr, value.shape);
+      value = reshape(arr, value.shape);
     end
   % In MATLAB, nested classes end up with a $ in the name, in Octave it's a .
   elseif isa(node, 'org.json.JSONObject$Null') || isa(node, 'org.json.JSONObject.Null')
@@ -208,88 +207,88 @@ end
 
 
 function y = base64decode(x)
-%BASE64DECODE Perform base64 decoding on a string.
-%
-%   BASE64DECODE(STR) decodes the given base64 string STR.
-%
-%   Any character not part of the 65-character base64 subset set is silently
-%   ignored.
-%
-%   This function is used to decode strings from the Base64 encoding specified
-%   in RFC 2045 - MIME (Multipurpose Internet Mail Extensions).  The Base64
-%   encoding is designed to represent arbitrary sequences of octets in a form
-%   that need not be humanly readable.  A 65-character subset ([A-Za-z0-9+/=])
-%   of US-ASCII is used, enabling 6 bits to be represented per printable
-%   character.
-%
-%   See also BASE64ENCODE.
+  %BASE64DECODE Perform base64 decoding on a string.
+  %
+  %   BASE64DECODE(STR) decodes the given base64 string STR.
+  %
+  %   Any character not part of the 65-character base64 subset set is silently
+  %   ignored.
+  %
+  %   This function is used to decode strings from the Base64 encoding specified
+  %   in RFC 2045 - MIME (Multipurpose Internet Mail Extensions).  The Base64
+  %   encoding is designed to represent arbitrary sequences of octets in a form
+  %   that need not be humanly readable.  A 65-character subset ([A-Za-z0-9+/=])
+  %   of US-ASCII is used, enabling 6 bits to be represented per printable
+  %   character.
+  %
+  %   See also BASE64ENCODE.
 
-%   Author:      Peter J. Acklam
-%   Time-stamp:  2004-09-20 08:20:50 +0200
-%   E-mail:      pjacklam@online.no
-%   URL:         http://home.online.no/~pjacklam
+  %   Author:      Peter J. Acklam
+  %   Time-stamp:  2004-09-20 08:20:50 +0200
+  %   E-mail:      pjacklam@online.no
+  %   URL:         http://home.online.no/~pjacklam
 
-%   Modified by Guillaume Flandin, May 2008
+  %   Modified by Guillaume Flandin, May 2008
 
-% check number of input arguments
-%--------------------------------------------------------------------------
+  % check number of input arguments
+  %--------------------------------------------------------------------------
 
-error(nargchk(1, 1, nargin));
+  error(nargchk(1, 1, nargin));
 
-% Perform the following mapping
-%--------------------------------------------------------------------------
-%   A-Z  ->  0  - 25         a-z  ->  26 - 51         0-9  ->  52 - 61
-%   +    ->  62              /    ->  63              =    ->  64
-%   anything else -> NaN
+  % Perform the following mapping
+  %--------------------------------------------------------------------------
+  %   A-Z  ->  0  - 25         a-z  ->  26 - 51         0-9  ->  52 - 61
+  %   +    ->  62              /    ->  63              =    ->  64
+  %   anything else -> NaN
 
-base64chars = NaN(1,256);
-base64chars('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=') = 0:64;
-x = base64chars(x);
+  base64chars = NaN(1,256);
+  base64chars('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=') = 0:64;
+  x = base64chars(x);
 
-% Remove/ignore any characters not in the base64 characters list or '='
-%--------------------------------------------------------------------------
+  % Remove/ignore any characters not in the base64 characters list or '='
+  %--------------------------------------------------------------------------
 
-x = x(~isnan(x));
+  x = x(~isnan(x));
 
-% Replace any incoming padding ('=' -> 64) with a zero pad
-%--------------------------------------------------------------------------
+  % Replace any incoming padding ('=' -> 64) with a zero pad
+  %--------------------------------------------------------------------------
 
-if     x(end-1) == 64, p = 2; x(end-1:end) = 0;
-elseif x(end)   == 64, p = 1; x(end) = 0;
-else                   p = 0;
-end
+  if     x(end-1) == 64, p = 2; x(end-1:end) = 0;
+  elseif x(end)   == 64, p = 1; x(end) = 0;
+  else                   p = 0;
+  end
 
-% Allocate decoded data array
-%--------------------------------------------------------------------------
+  % Allocate decoded data array
+  %--------------------------------------------------------------------------
 
-n = length(x) / 4;                               % number of groups
-x = reshape(uint8(x), 4, n);                     % input data
-y = zeros(3, n, 'uint8');                        % decoded data
+  n = length(x) / 4;                               % number of groups
+  x = reshape(uint8(x), 4, n);                     % input data
+  y = zeros(3, n, 'uint8');                        % decoded data
 
-% Rearrange every 4 bytes into 3 bytes
-%--------------------------------------------------------------------------
-%    00aaaaaa 00bbbbbb 00cccccc 00dddddd
-%
-% to form
-%
-%    aaaaaabb bbbbcccc ccdddddd
+  % Rearrange every 4 bytes into 3 bytes
+  %--------------------------------------------------------------------------
+  %    00aaaaaa 00bbbbbb 00cccccc 00dddddd
+  %
+  % to form
+  %
+  %    aaaaaabb bbbbcccc ccdddddd
 
-y(1,:) = bitshift(x(1,:), 2);                    % 6 highest bits of y(1,:)
-y(1,:) = bitor(y(1,:), bitshift(x(2,:), -4));    % 2 lowest bits of y(1,:)
+  y(1,:) = bitshift(x(1,:), 2);                    % 6 highest bits of y(1,:)
+  y(1,:) = bitor(y(1,:), bitshift(x(2,:), -4));    % 2 lowest bits of y(1,:)
 
-y(2,:) = bitshift(x(2,:), 4);                    % 4 highest bits of y(2,:)
-y(2,:) = bitor(y(2,:), bitshift(x(3,:), -2));    % 4 lowest bits of y(2,:)
+  y(2,:) = bitshift(x(2,:), 4);                    % 4 highest bits of y(2,:)
+  y(2,:) = bitor(y(2,:), bitshift(x(3,:), -2));    % 4 lowest bits of y(2,:)
 
-y(3,:) = bitshift(x(3,:), 6);                    % 2 highest bits of y(3,:)
-y(3,:) = bitor(y(3,:), x(4,:));                  % 6 lowest bits of y(3,:)
+  y(3,:) = bitshift(x(3,:), 6);                    % 2 highest bits of y(3,:)
+  y(3,:) = bitor(y(3,:), x(4,:));                  % 6 lowest bits of y(3,:)
 
-% Remove any zero pad that was added to make this a multiple of 24 bits
-%--------------------------------------------------------------------------
+  % Remove any zero pad that was added to make this a multiple of 24 bits
+  %--------------------------------------------------------------------------
 
-if p, y(end-p+1:end) = []; end
+  if p, y(end-p+1:end) = []; end
 
-% Reshape to a row vector
-%--------------------------------------------------------------------------
+  % Reshape to a row vector
+  %--------------------------------------------------------------------------
 
-y = reshape(y, 1, []);
+  y = reshape(y, 1, []);
 end

--- a/pymatbridge/matlab/util/json_v0.2.2/json/json_load.m
+++ b/pymatbridge/matlab/util/json_v0.2.2/json/json_load.m
@@ -122,15 +122,19 @@ function value = parse_data_(node, options)
       value.(safe_field) = parse_data_(node.get(javaObject('java.lang.String', key)), ...
                                        options);    
     end
-    % Check if the struct just decoded represents a complex number
-    if isfield(value,'real') && isfield(value, 'imag')
+    % Check if the struct just decoded represents an array or complex number
+    if isfield(value,'ndarray') && isfield(value, 'shape')
+      if isfield(value, 'data')
+          arr = typecast(base64decode(value.data), 'double');
+      else
+          r = typecast(base64decode(value.real), 'double');
+          im = typecast(base64decode(value.imag), 'double');
+          arr = complex(r, im);
+      end
+      value = reshape(arr, value.shape);
+    elseif isfield(value,'real') && isfield(value, 'imag')
       complex_value = complex(value.real, value.imag);
       value = complex_value;
-    end
-    % Check if the struct just decoded represents a numpy array
-    if isfield(value,'ndarray') && isfield(value, 'shape')
-      arr = typecast(base64decode(value.data), 'double');
-      value = reshape(arr, value.shape);
     end
   % In MATLAB, nested classes end up with a $ in the name, in Octave it's a .
   elseif isa(node, 'org.json.JSONObject$Null') || isa(node, 'org.json.JSONObject.Null')

--- a/pymatbridge/matlab/util/json_v0.2.2/json/json_load.m
+++ b/pymatbridge/matlab/util/json_v0.2.2/json/json_load.m
@@ -129,8 +129,9 @@ function value = parse_data_(node, options)
     end
     % Check if the struct just decoded represents a numpy array
     if isfield(value,'ndarray') && isfield(value, 'shape')
-      arr = typecast(unicode2native(value.data, 'latin-1'), 'double')
-      value = reshape(arr, value.shape);
+      disp(value.shape)
+      arr = typecast(base64decode(value.data), 'double');
+      value = arr;  %reshape(arr, value.shape);
     end
   % In MATLAB, nested classes end up with a $ in the name, in Octave it's a .
   elseif isa(node, 'org.json.JSONObject$Null') || isa(node, 'org.json.JSONObject.Null')
@@ -202,4 +203,93 @@ function vec = type_info_(value)
     fields = fieldnames(value);
     vec = [vec, uint8([fields{:}])];
   end
+end
+
+
+
+function y = base64decode(x)
+%BASE64DECODE Perform base64 decoding on a string.
+%
+%   BASE64DECODE(STR) decodes the given base64 string STR.
+%
+%   Any character not part of the 65-character base64 subset set is silently
+%   ignored.
+%
+%   This function is used to decode strings from the Base64 encoding specified
+%   in RFC 2045 - MIME (Multipurpose Internet Mail Extensions).  The Base64
+%   encoding is designed to represent arbitrary sequences of octets in a form
+%   that need not be humanly readable.  A 65-character subset ([A-Za-z0-9+/=])
+%   of US-ASCII is used, enabling 6 bits to be represented per printable
+%   character.
+%
+%   See also BASE64ENCODE.
+
+%   Author:      Peter J. Acklam
+%   Time-stamp:  2004-09-20 08:20:50 +0200
+%   E-mail:      pjacklam@online.no
+%   URL:         http://home.online.no/~pjacklam
+
+%   Modified by Guillaume Flandin, May 2008
+
+% check number of input arguments
+%--------------------------------------------------------------------------
+
+error(nargchk(1, 1, nargin));
+
+% Perform the following mapping
+%--------------------------------------------------------------------------
+%   A-Z  ->  0  - 25         a-z  ->  26 - 51         0-9  ->  52 - 61
+%   +    ->  62              /    ->  63              =    ->  64
+%   anything else -> NaN
+
+base64chars = NaN(1,256);
+base64chars('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=') = 0:64;
+x = base64chars(x);
+
+% Remove/ignore any characters not in the base64 characters list or '='
+%--------------------------------------------------------------------------
+
+x = x(~isnan(x));
+
+% Replace any incoming padding ('=' -> 64) with a zero pad
+%--------------------------------------------------------------------------
+
+if     x(end-1) == 64, p = 2; x(end-1:end) = 0;
+elseif x(end)   == 64, p = 1; x(end) = 0;
+else                   p = 0;
+end
+
+% Allocate decoded data array
+%--------------------------------------------------------------------------
+
+n = length(x) / 4;                               % number of groups
+x = reshape(uint8(x), 4, n);                     % input data
+y = zeros(3, n, 'uint8');                        % decoded data
+
+% Rearrange every 4 bytes into 3 bytes
+%--------------------------------------------------------------------------
+%    00aaaaaa 00bbbbbb 00cccccc 00dddddd
+%
+% to form
+%
+%    aaaaaabb bbbbcccc ccdddddd
+
+y(1,:) = bitshift(x(1,:), 2);                    % 6 highest bits of y(1,:)
+y(1,:) = bitor(y(1,:), bitshift(x(2,:), -4));    % 2 lowest bits of y(1,:)
+
+y(2,:) = bitshift(x(2,:), 4);                    % 4 highest bits of y(2,:)
+y(2,:) = bitor(y(2,:), bitshift(x(3,:), -2));    % 4 lowest bits of y(2,:)
+
+y(3,:) = bitshift(x(3,:), 6);                    % 2 highest bits of y(3,:)
+y(3,:) = bitor(y(3,:), x(4,:));                  % 6 lowest bits of y(3,:)
+
+% Remove any zero pad that was added to make this a multiple of 24 bits
+%--------------------------------------------------------------------------
+
+if p, y(end-p+1:end) = []; end
+
+% Reshape to a row vector
+%--------------------------------------------------------------------------
+
+y = reshape(y, 1, []);
 end

--- a/pymatbridge/matlab/util/json_v0.2.2/json/json_load.m
+++ b/pymatbridge/matlab/util/json_v0.2.2/json/json_load.m
@@ -127,6 +127,11 @@ function value = parse_data_(node, options)
       complex_value = complex(value.real, value.imag);
       value = complex_value;
     end
+    % Check if the struct just decoded represents a numpy array
+    if isfield(value,'ndarray') && isfield(value, 'shape')
+      arr = typecast(unicode2native(value.data, 'latin-1'), 'double')
+      value = reshape(arr, value.shape);
+    end
   % In MATLAB, nested classes end up with a $ in the name, in Octave it's a .
   elseif isa(node, 'org.json.JSONObject$Null') || isa(node, 'org.json.JSONObject.Null')
     value = [];

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -75,7 +75,7 @@ def decode_arr(data):
 
 
 # JSON decoder for arrays and complex numbers
-def as_complex(dct):
+def decode_pymat(dct):
     if 'ndarray' in dct and 'data' in dct:
         value = decode_arr(dct['data'])
         shape = decode_arr(dct['shape'])
@@ -243,7 +243,7 @@ class _Session(object):
     def _json_response(self, **kwargs):
         if self.running:
             time.sleep(0.05)
-        return json.loads(self._response(**kwargs), object_hook=as_complex)
+        return json.loads(self._response(**kwargs), object_hook=decode_pymat)
 
     # Run a function in Matlab and return the result
     def run_func(self, func_path, func_args=None):

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -36,7 +36,11 @@ class PymatEncoder(json.JSONEncoder):
         if isinstance(obj, complex):
             return {'real':obj.real, 'imag':obj.imag}
         if isinstance(obj, ndarray):
-            return obj.tolist()
+            if obj.size > 100:
+                return {'ndarray': True, 'shape': list(obj.shape),
+                        'data': obj.astype(float).tobytes().encode('latin-1')}
+            else:
+                return obj.tolist()
         if isinstance(obj, generic):
             return obj.item()
         # Handle the default case

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -32,41 +32,62 @@ except ImportError:
         pass
 
 
+def encode_ndarray(obj):
+    """Write a numpy array and its shape to base64 buffers"""
+    shape = obj.shape
+    if len(shape) == 1:
+        shape = (obj.shape[0], 1)
+    if obj.flags.c_contiguous:
+        obj = obj.T
+    elif not obj.flags.f_contiguous:
+        obj = asfortranarray(obj)
+    data = obj.astype(float64).tobytes()
+    data = codecs.encode(data, 'base64').decode('utf-8')
+    return data, shape
+
+
 # JSON encoder extension to handle complex numbers and numpy arrays
 class PymatEncoder(json.JSONEncoder):
 
     def default(self, obj):
-        if isinstance(obj, complex):
-            return {'real': obj.real, 'imag': obj.imag}
-        if isinstance(obj, ndarray) and not obj.dtype.kind == 'c':
-            shape = obj.shape
-            if len(shape) == 1:
-                shape = (obj.shape[0], 1)
-            if obj.flags.c_contiguous:
-                obj = obj.T
-            elif not obj.flags.f_contiguous:
-                obj = asfortranarray(obj)
-            data = obj.astype(float64).tobytes()
-            data = codecs.encode(data, 'base64').decode('utf-8')
+        if isinstance(obj, ndarray) and obj.dtype.kind in 'uif':
+            data, shape = encode_ndarray(obj)
             return {'ndarray': True, 'shape': shape, 'data': data}
+        elif isinstance(obj, ndarray) and obj.dtype.kind == 'c':
+            real, shape = encode_ndarray(obj.real.copy())
+            imag, _ = encode_ndarray(obj.imag.copy())
+            return {'ndarray': True, 'shape': shape,
+                    'real': real, 'imag': imag}
         elif isinstance(obj, ndarray):
             return obj.tolist()
-        if isinstance(obj, generic):
+        elif isinstance(obj, complex):
+            return {'real': obj.real, 'imag': obj.imag}
+        elif isinstance(obj, generic):
             return obj.item()
         # Handle the default case
         return json.JSONEncoder.default(self, obj)
 
 
-# JSON decoder for complex numbers
+def decode_arr(data):
+    """Extract a numpy array from a base64 buffer"""
+    data = data.encode('utf-8')
+    return frombuffer(codecs.decode(data, 'base64'), float64)
+
+
+# JSON decoder for arrays and complex numbers
 def as_complex(dct):
-    if 'real' in dct and 'imag' in dct:
-        return complex(dct['real'], dct['imag'])
     if 'ndarray' in dct and 'data' in dct:
-        data = dct['data'].encode('utf-8')
-        shape = dct['shape'].encode('utf-8')
-        value = frombuffer(codecs.decode(data, 'base64'), float64)
-        shape = frombuffer(codecs.decode(shape, 'base64'), float64)
+        value = decode_arr(dct['data'])
+        shape = decode_arr(dct['shape'])
         return value.reshape(shape, order='F')
+    elif 'ndarray' in dct and 'imag' in dct:
+        real = decode_arr(dct['real'])
+        imag = decode_arr(dct['imag'])
+        shape = decode_arr(dct['shape'])
+        data = real + 1j * imag
+        return data.reshape(shape, order='F')
+    elif 'real' in dct and 'imag' in dct:
+        return complex(dct['real'], dct['imag'])
     return dct
 
 MATLAB_FOLDER = '%s/matlab' % os.path.realpath(os.path.dirname(__file__))

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -9,7 +9,9 @@ Part of Python-MATLAB-bridge, Max Jaderberg 2012
 This is a modified version using ZMQ, Haoxing Zhang Jan.2014
 """
 
-import os, time
+import os
+import time
+import codecs
 import zmq
 import subprocess
 import sys
@@ -17,7 +19,7 @@ import json
 from uuid import uuid4
 
 try:
-    from numpy import ndarray, generic
+    from numpy import ndarray, generic, float64
 except ImportError:
     class ndarray:
         pass
@@ -37,8 +39,8 @@ class PymatEncoder(json.JSONEncoder):
             return {'real':obj.real, 'imag':obj.imag}
         if isinstance(obj, ndarray):
             if obj.size > 100:
-                return {'ndarray': True, 'shape': list(obj.shape),
-                        'data': obj.astype(float).tobytes().encode('latin-1')}
+                return {'ndarray': True, 'shape': obj.shape,
+                        'data': codecs.encode(obj.astype(float64).tobytes(), 'base64').decode('utf-8')}
             else:
                 return obj.tolist()
         if isinstance(obj, generic):

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -36,7 +36,7 @@ def encode_ndarray(obj):
     """Write a numpy array and its shape to base64 buffers"""
     shape = obj.shape
     if len(shape) == 1:
-        shape = (obj.shape[0], 1)
+        shape = (1, obj.shape[0])
     if obj.flags.c_contiguous:
         obj = obj.T
     elif not obj.flags.f_contiguous:

--- a/pymatbridge/tests/test_array.py
+++ b/pymatbridge/tests/test_array.py
@@ -19,7 +19,7 @@ class TestArray:
 
     # Pass a 1000*1000 array to Matlab
     def test_array_size(self):
-        array = np.random.random_sample((50,50)).tolist()
+        array = np.random.random_sample((50,50))
         res = self.mlab.run_func("array_size.m",{'val':array})['result']
         npt.assert_almost_equal(res, array, decimal=8, err_msg = "test_array_size: error")
 

--- a/pymatbridge/tests/test_get_variable.py
+++ b/pymatbridge/tests/test_get_variable.py
@@ -30,8 +30,8 @@ class TestGetVariable:
         self.mlab.run_code("a = [1 2 3 4]")
         self.mlab.run_code("b = [1 2; 3 4]")
 
-        npt.assert_equal(self.mlab.get_variable('a'), [1,2,3,4])
-        npt.assert_equal(self.mlab.get_variable('b'), [[1,2],[3,4]])
+        npt.assert_equal(self.mlab.get_variable('a'), [[1.,2.,3.,4.]])
+        npt.assert_equal(self.mlab.get_variable('b'), [[1.,2.],[3.,4.]])
 
 
     # Try to get a non-existent variable

--- a/pymatbridge/tests/test_magic.py
+++ b/pymatbridge/tests/test_magic.py
@@ -62,7 +62,7 @@ class TestMagic:
         # Get the result back to Python
         self.ip.run_cell_magic('matlab', '-o actual', 'actual = res')
 
-        self.ip.run_cell("expected = np.array([2, 4, 6])")
+        self.ip.run_cell("expected = np.array([[2., 4., 6.]])")
         npt.assert_almost_equal(self.ip.user_ns['actual'],
                                 self.ip.user_ns['expected'], decimal=7)
 
@@ -82,7 +82,7 @@ class TestMagic:
     # Matlab struct type should be converted to a Python dict
     def test_struct(self):
         self.ip.run_cell('num = 2.567')
-        self.ip.run_cell('num_array = np.array([1.2,3.4,5.6])')
+        self.ip.run_cell('num_array = np.array([1.2,3.4,5.6]).reshape(3,1)')
         self.ip.run_cell('str = "Hello World"')
         self.ip.run_cell_magic('matlab', '-i num,num_array,str -o obj',
                                 'obj.num = num;obj.num_array = num_array;obj.str = str;')

--- a/pymatbridge/tests/test_magic.py
+++ b/pymatbridge/tests/test_magic.py
@@ -82,11 +82,11 @@ class TestMagic:
     # Matlab struct type should be converted to a Python dict
     def test_struct(self):
         self.ip.run_cell('num = 2.567')
-        self.ip.run_cell('num_array = np.array([1.2,3.4,5.6]).reshape(3,1)')
+        self.ip.run_cell('num_array = np.array([1.2,3.4,5.6])')
         self.ip.run_cell('str = "Hello World"')
         self.ip.run_cell_magic('matlab', '-i num,num_array,str -o obj',
                                 'obj.num = num;obj.num_array = num_array;obj.str = str;')
         npt.assert_equal(isinstance(self.ip.user_ns['obj'], dict), True)
         npt.assert_equal(self.ip.user_ns['obj']['num'], self.ip.user_ns['num'])
-        npt.assert_equal(self.ip.user_ns['obj']['num_array'], self.ip.user_ns['num_array'])
+        npt.assert_equal(self.ip.user_ns['obj']['num_array'].squeeze(), self.ip.user_ns['num_array'])
         npt.assert_equal(self.ip.user_ns['obj']['str'], self.ip.user_ns['str'])


### PR DESCRIPTION
Bottom line: array passing is 10X faster without using temporary files.
Uses base64 encoding to pass arrays between Matlab and Python using a similar method to `complex`.  For Python, numeric-type arrays are converted to float64 and then passed as a dictionary.  For Matlab, numeric arrays are converted to double and sent back as a structure.   
Also handles complex type arrays.  Side benefit: arrays are now returned as ndarrays. 

```python
With Base64:
In [3]: %time mlab.set_variable('ha', np.linspace(1.1, 2, 10000).reshape(100, 100))
CPU times: user 4.31 ms, sys: 1.61 ms, total: 5.92 ms
Wall time: 163 ms
Out[3]: {'success': 'true', 'result': 1, 'message': 'Successfully completed request'}

In [4]: %time b = mlab.get_variable('ha')
CPU times: user 3.93 ms, sys: 1.09 ms, total: 5.02 ms
Wall time: 66.8 ms

In [5]: b
Out[5]: b
array([[ 1.1       ,  1.10009001,  1.10018002, ...,  1.10873087,
         1.10882088,  1.10891089],
       [ 1.1090009 ,  1.10909091,  1.10918092, ...,  1.11773177,
         1.11782178,  1.11791179],
       [ 1.1180018 ,  1.11809181,  1.11818182, ...,  1.12673267,
         1.12682268,  1.12691269],
       ..., 
       [ 1.97308731,  1.97317732,  1.97326733, ...,  1.98181818,
         1.98190819,  1.9819982 ],
       [ 1.98208821,  1.98217822,  1.98226823, ...,  1.99081908,
         1.99090909,  1.9909991 ],
       [ 1.99108911,  1.99117912,  1.99126913, ...,  1.99981998,
         1.99990999,  2.        ]])

On master branch:
In [5]: %time mlab.set_variable('ha', np.linspace(1.1, 2, 10000).reshape(100, 100))
CPU times: user 16.7 ms, sys: 1.08 ms, total: 17.7 ms
Wall time: 1.19 s
Out[5]: {'result': 1, 'message': 'Successfully completed request', 'success': 'true'}

In [6]: %time b = mlab.get_variable('ha')
CPU times: user 5.33 ms, sys: 1.2 ms, total: 6.54 ms
Wall time: 821 ms

In [7]: type(b)
Out[7]: list