### PR TITLE
Backward compatible handling of NumPy arrays

### DIFF
--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -66,7 +66,12 @@ def encode_ndarray(obj):
         obj = obj.T
     elif not obj.flags.f_contiguous:
         obj = asfortranarray(obj)
-    data = obj.astype(float64).tobytes()
+
+    try:
+        data = obj.astype(float64).tobytes()
+    except AttributeError:
+        data = obj.astype(float64).tostring()
+
     data = codecs.encode(data, 'base64').decode('utf-8')
     return data, shape
 


### PR DESCRIPTION
Older versions of NumPy don't supply the tobytes method. However, it is stated in the NumPy release notes for 1.9.0 ( http://docs.scipy.org/doc/numpy/release.html ) ( https://github.com/numpy/numpy/blob/master/doc/release/1.9.0-notes.rst ) that this behaves the same as tostring. So, this workaround tries to use tostring if tobytes fails.