### PR TITLE
Forward MatlabInterperterError to the user

### DIFF
--- a/pymatbridge/matlab_magic.py
+++ b/pymatbridge/matlab_magic.py
@@ -211,6 +211,8 @@ class MatlabMagics(Magics):
             else:
                 e_s = "There was an error running the code:\n %s"%code
                 result_dict = self.eval(code)
+        except MatlabInterperterError:
+            raise
         except:
             e_s += "\n-----------------------"
             e_s += "\nAre you sure Matlab is started?"


### PR DESCRIPTION
This PR is to address arokem#117. It ensures that MatlabInterperterError is re-raised so the user can get some feedback as to what caused the error if there was one. If anyone wants to improve on it, feel free.