### PR TITLE
Pipe stdout to subprocess.PIPE

### DIFF
--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -204,7 +204,8 @@ class _Session(object):
         ])
         command = '%s %s %s "%s"' % (self.executable, self.startup_options,
                                      self._execute_flag(), ','.join(code))
-        subprocess.Popen(command, shell=True, stdin=subprocess.PIPE)
+        subprocess.Popen(command, shell=True, stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE)
 
     # Start server/client session and make the connection
     def start(self):


### PR DESCRIPTION
You're already capturing `stdout` using `diary`, the test suite still passes, and we get no double print. :smile: