### PR TITLE
Update handling of nargout

### DIFF
--- a/pymatbridge/matlab/util/pymat_feval.m
+++ b/pymatbridge/matlab/util/pymat_feval.m
@@ -30,9 +30,13 @@ function json_response = pymat_feval(req)
     else
         arguments = '';
     end
-    
-    [resp{1:nargout}] = run_dot_m(func_path, arguments);
-    response.result = resp; 
+
+    [resp{1:req.nargout}] = run_dot_m(func_path, arguments, req.nargout);
+    if req.nargout == 1
+        response.result = resp{1};
+    else
+        response.result = resp;
+    end
     response.success = 'true';
     response.message = 'Successfully completed request';
 

--- a/pymatbridge/matlab/util/run_dot_m.m
+++ b/pymatbridge/matlab/util/run_dot_m.m
@@ -1,28 +1,25 @@
 % Max Jaderberg 2011
 
-function result = run_dot_m( file_to_run, arguments )
+function varargout = run_dot_m( file_to_run, arguments, nout )
 %RUN_DOT_M Runs the given .m file with the argument struct given
 %   For exmaple run_dot_m('/path/to/function.m', args);
 %   args is a struct containing the arguments. function.m must take only
 %   one parameter, the argument structure
 
-    [dir, func_name, ext] = fileparts(file_to_run);
+    [dname, func_name, ext] = fileparts(file_to_run);
 
-    if ~size(ext)
-        result = 'Error: Need to give path to .m file';
-        return
+    if size(ext)
+        if ~strcmp(ext, '.m')
+            varargout = 'Error: Need to give path to .m file';
+            return
+        end
     end
 
-    if ~strcmp(ext, '.m')
-        result = 'Error: Need to give path to .m file';
-        return
+    % Add function path to current path
+    if size(dname)
+        addpath(dname);
     end
 
-%     Add function path to current path
-    addpath(dir);
-    if isstruct(arguments)
-        result = feval(func_name, arguments);
-    else
-        result = feval(func_name);
-    end
+    [varargout{1:nout}] = feval(func_name, arguments);
+
 end

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -264,10 +264,11 @@ class _Session(object):
         return json.loads(self._response(**kwargs), object_hook=decode_pymat)
 
     # Run a function in Matlab and return the result
-    def run_func(self, func_path, func_args=None):
+    def run_func(self, func_path, func_args=None, nargout=1):
         return self._json_response(cmd='run_function',
                                    func_path=func_path,
-                                   func_args=func_args)
+                                   func_args=func_args,
+                                   nargout=nargout)
 
     # Run some code in Matlab command line provide by a string
     def run_code(self, code):


### PR DESCRIPTION
I also changed the semantics of `run_func` a bit.  You can now call built-in functions and pass a single argument that is not a dictionary.  Here was my test case:

```python
In [2]: from pymatbridge import Matlab

In [3]: m = Matlab();m.start()
Starting MATLAB on ZMQ socket ipc:///tmp/pymatbridge
Send 'exit' command to kill the server
.....MATLAB started and connected!
Out[3]: True

In [4]: res  = m.run_func('svd', np.array([[1,2],[1,3]]), nargout=3)

In [5]: U, S, V = res['result']

In [6]: U, S, V
Out[6]: 
(array([[-0.57604844, -0.81741556],
        [-0.81741556,  0.57604844]]), array([[ 3.86432845,  0.        ],
        [ 0.        ,  0.25877718]]), array([[-0.36059668, -0.93272184],
        [-0.93272184,  0.36059668]]))
```

This definitely warrants new test cases and some thought about to handle an array (list) of arguments or no arguments, but it definitely demonstrates the `nargout` behaviour`.