### PR TITLE
More nargout tests and handle tuple arguments

### DIFF
--- a/pymatbridge/matlab/util/run_dot_m.m
+++ b/pymatbridge/matlab/util/run_dot_m.m
@@ -1,12 +1,13 @@
 % Max Jaderberg 2011
 
-function varargout = run_dot_m( file_to_run, arguments, nout )
-%RUN_DOT_M Runs the given .m file with the argument struct given
-%   For exmaple run_dot_m('/path/to/function.m', args);
-%   args is a struct containing the arguments. function.m must take only
-%   one parameter, the argument structure
+function varargout = run_dot_m( func_to_run, arguments, nout )
+%RUN_DOT_M Runs the given function or .m file with the arguments given
+%   and the nout selected
+%   For exmaple run_dot_m('/path/to/function.m', args, 1);
+%   arguments can be a scalar, as cell, or struct containing the arguments.
+%   If it is a struct, func_to_run must take only one parameter, the argument structure
 
-    [dname, func_name, ext] = fileparts(file_to_run);
+    [dname, func_name, ext] = fileparts(func_to_run);
 
     if size(ext)
         if ~strcmp(ext, '.m')
@@ -20,6 +21,10 @@ function varargout = run_dot_m( file_to_run, arguments, nout )
         addpath(dname);
     end
 
-    [varargout{1:nout}] = feval(func_name, arguments);
+    if iscell(arguments)
+        [varargout{1:nout}] = feval(func_name, arguments{:});
+    else
+        [varargout{1:nout}] = feval(func_name, arguments);
+    end
 
 end

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -263,15 +263,35 @@ class _Session(object):
     def _json_response(self, **kwargs):
         return json.loads(self._response(**kwargs), object_hook=decode_pymat)
 
-    # Run a function in Matlab and return the result
     def run_func(self, func_path, func_args=None, nargout=1):
+        """Run a function in Matlab and return the result.
+
+        Parameters
+        ----------
+        func_path: str
+            Name of function to run or a path to an m-file.
+        func_args: object
+            Function args to send to the function.
+        nargout: int
+            Desired number of return arguments.
+
+        Returns
+        -------
+        Result dictionary with keys: 'message', 'result', and 'success'
+        """
         return self._json_response(cmd='run_function',
                                    func_path=func_path,
                                    func_args=func_args,
                                    nargout=nargout)
 
-    # Run some code in Matlab command line provide by a string
     def run_code(self, code):
+        """Run some code in Matlab command line provide by a string
+
+        Parameters
+        ----------
+        code : str
+            Code to send for evaluation.
+        """
         return self._json_response(cmd='run_code', code=code)
 
     def get_variable(self, varname, default=None):

--- a/pymatbridge/tests/test_run_code.py
+++ b/pymatbridge/tests/test_run_code.py
@@ -71,9 +71,26 @@ class TestRunCode:
         U, S, V = res['result']
         npt.assert_almost_equal(U, np.array([[-0.57604844, -0.81741556],
                                              [-0.81741556, 0.57604844]]))
-        
+
         npt.assert_almost_equal(S, np.array([[ 3.86432845, 0.],
                                              [ 0., 0.25877718]]))
 
         npt.assert_almost_equal(V, np.array([[-0.36059668, -0.93272184],
                                              [-0.93272184, 0.36059668]]))
+
+        res = self.mlab.run_func('svd', np.array([[1,2],[1,3]]), nargout=1)
+        s = res['result']
+        npt.assert_almost_equal(s, [[ 3.86432845], [ 0.25877718]])
+
+        res = self.mlab.run_func('close', 'all', nargout=0)
+        assert res['result'] == []
+
+    def test_tuple_args(self):
+        res = self.mlab.run_func('ones', (1, 2))
+        npt.assert_almost_equal(res['result'], [[1, 1]])
+
+        res = self.mlab.run_func('chol',
+                                 (np.array([[2, 2], [1, 1]]), 'lower'))
+        npt.assert_almost_equal(res['result'],
+                                [[1.41421356, 0.],
+                                 [0.70710678, 0.70710678]])


### PR DESCRIPTION
Add explicit tests for `nargout=1` and `nargout=0` in `run_func`.
Add support for tuples and and cell-like objects in `run_func`.
Beef up some documentation.