### PR TITLE
Add Python 3.4 to Travis Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ deploy:
 env:
     - CONDA="python=2.7 numpy=1.7"
     - CONDA="python=3.3 numpy"
+    - CONDA="python=3.4 numpy"
 before_install:
   - sudo apt-add-repository -y ppa:octave/stable;
   - sudo apt-get update -qq;


### PR DESCRIPTION
As a result of some earlier refactoring, the Python 3.4 build is now cooperating.