### PR TITLE
Start the session if you try and run code

### DIFF
--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -285,6 +285,8 @@ class _Session(object):
         -------
         Result dictionary with keys: 'message', 'result', and 'success'
         """
+        if not self.started:
+            self.start()
         nargout = kwargs.pop('nargout', 1)
         func_args += tuple(item for pair in zip(kwargs.keys(), kwargs.values())
                            for item in pair)

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -168,7 +168,6 @@ class _Session(object):
         self.context = None
         self.socket = None
         atexit.register(self.stop)
-        return self
 
     def _program_name(self):  # pragma: no cover
         raise NotImplemented
@@ -214,10 +213,9 @@ class _Session(object):
         if self.is_connected():
             print("%s started and connected!" % self._program_name())
             self.set_plot_settings()
-            return True
+            return self
         else:
-            print("%s failed to start" % self._program_name())
-            return False
+            raise ValueError("%s failed to start" % self._program_name())
 
     def _response(self, **kwargs):
         req = json.dumps(kwargs, cls=PymatEncoder)

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -168,6 +168,7 @@ class _Session(object):
         self.context = None
         self.socket = None
         atexit.register(self.stop)
+        return self
 
     def _program_name(self):  # pragma: no cover
         raise NotImplemented
@@ -286,7 +287,8 @@ class _Session(object):
         Result dictionary with keys: 'message', 'result', and 'success'
         """
         if not self.started:
-            self.start()
+            raise ValueError('Session not started, use start()')
+
         nargout = kwargs.pop('nargout', 1)
         func_args += tuple(item for pair in zip(kwargs.keys(), kwargs.values())
                            for item in pair)


### PR DESCRIPTION
Prior to this change, trying to run `m.version()` without calling `m.start()` gave this unhelpful message:

```python
/home/silvester/workspace/python-matlab-bridge/pymatbridge/pymatbridge.py in _response(self, **kwargs)
    221     def _response(self, **kwargs):
    222         req = json.dumps(kwargs, cls=PymatEncoder)
--> 223         self.socket.send_string(req)
    224         resp = self.socket.recv_string()
    225         return resp

AttributeError: 'NoneType' object has no attribute 'send_string'
```

Also allows you to use `m = Matlab().start()`