### PR TITLE
Fix matlabserver shutdown behavior

### DIFF
--- a/pymatbridge/matlab/matlabserver.m
+++ b/pymatbridge/matlab/matlabserver.m
@@ -6,6 +6,8 @@ function matlabserver(socket_address)
 json_startup
 messenger('init', socket_address);
 
+c=onCleanup(@()exit);
+
 while(1)
     msg_in = messenger('listen');
     req = json_load(msg_in);
@@ -16,7 +18,6 @@ while(1)
 
         case {'exit'}
             messenger('exit');
-            clear mex;
             break;
 
         case {'eval'}

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -187,8 +187,7 @@ class _Session(object):
     def _run_server(self):
         code = self._preamble_code()
         code.extend([
-            "matlabserver('%s')" % self.socket_addr,
-            'exit'
+            "matlabserver('%s')" % self.socket_addr
         ])
         command = '%s %s %s "%s"' % (self.executable, self.startup_options,
                                      self._execute_flag(), ','.join(code))


### PR DESCRIPTION
Fixes #168, addresses #164.

I could not find a way to reliably interrupt the Matlab process and recover from it, but at least now Ctrl+C results in a clean shutdown of the Matlab process.  