### PR TITLE
messenger should use zmq syncronously and block

### DIFF
--- a/messenger/mexa64/local.cfg
+++ b/messenger/mexa64/local.cfg
@@ -1,4 +1,4 @@
-MATLAB_BIN=/home/silvester/matlab2014b/bin/
+MATLAB_BIN=
 OCTAVE_INC=/usr/include
 OCTAVE_LIB=/usr/lib/x86_64-linux-gnu/
 ZMQ_INC=

--- a/messenger/mexw64/local.cfg
+++ b/messenger/mexw64/local.cfg
@@ -1,4 +1,4 @@
-MATLAB_BIN="C:\Program Files\MATLAB\2014b\bin"
+MATLAB_BIN="C:\Program Files\MATLAB\2013a\bin"
 OCTAVE_INC="C:\Octave\Octave-3.8.2\include\octave-3.8.2\octave"
 OCTAVE_LIB="C:\Octave\Octave-3.8.2\lib\octave\3.8.2"
 ZMQ_INC="C:\zeromq-4.0.5\include"


### PR DESCRIPTION
By using the asyncronous API while listening, excessive CPU usage
occurs.

A longer-term workaround may be to use a poller with a reasonable
timeout (such as 20ms).

This fixes #175.