### PR TITLE
Respect current directory when starting MATLAB on Windows

### DIFF
--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -176,10 +176,11 @@ class _Session(object):
         # suppress warnings while loading the path, in the case of
         # overshadowing a built-in function on a newer version of
         # Matlab (e.g. isrow)
-        return ["old_warning_state = warning('off','all')",
-                "addpath(genpath('%s'))" % MATLAB_FOLDER,
-                "warning(old_warning_state)",
-                "clear old_warning_state"]
+        return ["old_warning_state = warning('off','all');",
+                "addpath(genpath('%s'));" % MATLAB_FOLDER,
+                "warning(old_warning_state);",
+                "clear('old_warning_state');",
+                "cd('%s');" % os.getcwd()]
 
     def _execute_flag(self):  # pragma: no cover
         raise NotImplemented


### PR DESCRIPTION
Current directory was not respected on Windows when `-automation` flag is used, as previously [reported here](http://www.mathworks.com/matlabcentral/answers/58372-can-t-change-startup-directory-when-calling-matlab-with-automation-from-command-line). Changing the directory therefore allows for more consistent behavior across different platforms.

I've also suppressed verbose startup output by suffixing commands with semicolon.
