### PR TITLE
Include the stack trace in the response on error.

### DIFF
--- a/pymatbridge/matlab/util/pymat_eval.m
+++ b/pymatbridge/matlab/util/pymat_eval.m
@@ -5,7 +5,10 @@ function json_response = pymat_eval(req);
 %
 %   This allows you to run any matlab code. req should be a struct with the
 %   following fields:
-%       code: a string which contains the code to be run in the matlab session
+%       dname: The name of a directory to add to the runtime path before attempting to run the code.
+%       func_name: The name of a function to invoke.
+%       func_args: An array of arguments to send to the function.
+%       nargout: An int specifying how many output arguments are expected.
 %
 %   Should return a json object containing the result.
 %
@@ -14,6 +17,7 @@ function json_response = pymat_eval(req);
 response.success = true;
 response.content = '';
 response.result = '';
+response.stack = {};
 
 close all hidden;
 
@@ -67,6 +71,51 @@ catch ME
 	diary('off');
 	response.success = false;
 	response.content.stdout = ME.message;
+
+  % Retrieve the stack trace.
+  if ~exist('OCTAVE_VERSION', 'builtin');
+    % For MATLAB, just grab it off the exception.
+    response.stack = ME.stack;
+  else
+    % Octave exceptions don't seem to have a 'stack' field, so we use lasterror
+    % instead. lasterror exists in MATLAB too, but it doesn't seem to return
+    % the correct stack trace in this case.
+    err = lasterror();
+    stack = err.stack;
+
+    % Strip off fields that aren't available on MException.
+    stack = rmfield(stack, {'column', 'context', 'scope'});
+
+    % The 'name' fields here look like 'foo>bar' in Octave, where foo is the
+    % outermost calling function, and bar is the current function. With
+    % MException there's only 'bar' so let's strip off the 'foo>'.
+
+    % n.b. strsplit doesn't work in Octave when the delimiter is < or >.
+    % This bug is fixed in Octave 4.0 (http://savannah.gnu.org/bugs/?44641)
+    % but we support 3.8, so we use the regex mode as a workaround.
+    for i = 1:numel(stack)
+      name = stack(i).name;
+      name = strsplit(name, '>', 'delimitertype', 'regularexpression');
+      stack(i).name = name{end};
+    end
+
+    response.stack = stack;
+  end
+
+  % Strip off the last two frames -- these correspond to pymat_eval and
+  % matlabserver, which we don't want to expose.
+  response.stack = response.stack(1:end-2, :);
+
+  % FIXME: The stack is returned as a nx1 struct array, and in Octave json_dump
+  % throws an error trying to serialize it. Let's just transpose it for now.
+  response.stack = response.stack';
+  % FIXME: json_dump loops infinitely if this is a 1x0 struct array, so
+  % let's just turn it back into an empty array if so.
+  if ndims(response.stack) == 2 && ...
+    size(response.stack, 1) == 1 && ...
+    size(response.stack, 2) == 0
+    response.stack = {};
+  end
 end
 
 json_response = json_dump(response);

--- a/pymatbridge/tests/test_run_code.py
+++ b/pymatbridge/tests/test_run_code.py
@@ -1,3 +1,5 @@
+import os
+
 import pymatbridge as pymat
 from pymatbridge.compat import text_type
 import numpy as np
@@ -64,3 +66,19 @@ class TestRunCode:
             npt.assert_equal(message, "'this_is_nonsense' undefined near line 1 column 1")
         else:
             npt.assert_equal(message, "Undefined function or variable 'this_is_nonsense'.")
+
+    def test_stack_traces(self):
+        this_dir = os.path.abspath(os.path.dirname(__file__))
+        test_file = os.path.join(this_dir, 'test_stack_trace.m')
+
+        self.mlab.run_code("addpath('%s')" % this_dir)
+        response = self.mlab.run_code('test_stack_trace(10)')
+        npt.assert_equal(response['stack'], [
+            {'name': 'baz', 'line': 14, 'file': test_file},
+            {'name': 'bar', 'line': 10, 'file': test_file},
+            {'name': 'foo', 'line': 6, 'file': test_file},
+            {'name': 'test_stack_trace', 'line': 2, 'file': test_file}
+        ])
+
+        response = self.mlab.run_code('x = 2')
+        npt.assert_equal(response['stack'], [])

--- a/pymatbridge/tests/test_stack_trace.m
+++ b/pymatbridge/tests/test_stack_trace.m
@@ -1,0 +1,15 @@
+function o = test_stack_trace(input)
+  o = foo(input);
+end
+
+function o = foo(input)
+  o = bar(input)
+end
+
+function o = bar(input)
+  o = baz(input)
+end
+
+function o = baz(input)
+  o = quux(input)
+end


### PR DESCRIPTION
If an error happens while executing the code, grab the stack trace and include it in a new `stack` field on the response. (See the test for what this field looks like).

Unfortunately the code is a little awkward because I wanted the output to be the same in both MATLAB and Octave.

This is relevant for #160, although it doesn't quite solve it. It shouldn't be hard to add some code to the matlab magic that uses the `stack` field and builds a nice error message out of it like MATLAB does. I don't really use ipython so I'm not really the best person to write & test this.