### PR TITLE
Made json encode/decode reversible

### DIFF
--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -94,7 +94,9 @@ def decode_arr(data):
 def decode_pymat(dct):
     if 'ndarray' in dct and 'data' in dct:
         value = decode_arr(dct['data'])
-        shape = decode_arr(dct['shape']).astype(int)
+        shape = dct['shape']
+        if type(dct['shape']) is unicode:
+            shape = decode_arr(dct['shape']).astype(int)
         return value.reshape(shape, order='F')
     elif 'ndarray' in dct and 'imag' in dct:
         real = decode_arr(dct['real'])

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -95,7 +95,7 @@ def decode_pymat(dct):
     if 'ndarray' in dct and 'data' in dct:
         value = decode_arr(dct['data'])
         shape = dct['shape']
-        if type(dct['shape']) is unicode:
+        if type(dct['shape']) is not list:
             shape = decode_arr(dct['shape']).astype(int)
         return value.reshape(shape, order='F')
     elif 'ndarray' in dct and 'imag' in dct:


### PR DESCRIPTION
In a scenario where PyMatBridge is used with other Python ZMQ sessions, it would make sense for the JSON encoder and decoder to be compatible, so that they can be used to send variables over a channel from one Python program to another. 

Currently, what Python encodes, Matlab can decode and vice versa. But what Python encodes cannot be decoded by itself. This pull requests addresses this issue and is also backward compatible and doesn't break any current usage. I only found this non-reversibility bug in ndarrays and this fixes it. 