### PR TITLE
Force a rehash of user functions

### DIFF
--- a/pymatbridge/matlab/util/pymat_eval.m
+++ b/pymatbridge/matlab/util/pymat_eval.m
@@ -31,6 +31,9 @@ try
         addpath(req.dname);
     end
 
+    % force a rehash of user functions
+    rehash
+
     if iscell(req.func_args)
         [resp{1:req.nargout}] = feval(req.func_name, req.func_args{:});
     else


### PR DESCRIPTION
If a user is editing a file, the changes are not reflected in the pymatbridge Matlab session.  This forces a behavior consistent with the Matlab command window.

See https://github.com/Calysto/matlab_kernel/issues/14#issuecomment-124966296.