### PR TITLE
IPython.nbformat is now nbformat in Jupyter

### DIFF
--- a/pymatbridge/publish.py
+++ b/pymatbridge/publish.py
@@ -1,5 +1,5 @@
-import IPython.nbformat.v4 as nbformat
-from IPython.nbformat import write as nbwrite
+import nbformat.v4 as nbformat
+from nbformat import write as nbwrite
 import numpy as np
 
 


### PR DESCRIPTION
I've changed the imports (two) in publish.py from IPython.nbformat to
nbformat. I'm concerned that this breaks backwards compatibility
though. I'm not sure how to assure that if nbformat doesn't exist,
Python.nbformat will be.