### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/arokem/python-matlab-bridge.svg?branch=master)](https://travis-ci.org/arokem/python-matlab-bridge)
 [![Coverage Status](https://coveralls.io/repos/arokem/python-matlab-bridge/badge.svg?branch=master)](https://coveralls.io/r/arokem/python-matlab-bridge?branch=master)
-[![Latest Version](https://pypip.in/version/pymatbridge/badge.svg?style=flat)](https://pypi.python.org/pypi/pymatbridge/)
-[![License](https://pypip.in/license/pymatbridge/badge.svg?style=flat)](https://pypi.python.org/pypi/pymatbridge/)
+[![Latest Version](https://img.shields.io/pypi/v/pymatbridge.svg?style=flat)](https://pypi.python.org/pypi/pymatbridge/)
+[![License](https://img.shields.io/pypi/l/pymatbridge.svg?style=flat)](https://pypi.python.org/pypi/pymatbridge/)
 [![Join the chat at https://gitter.im/arokem/python-matlab-bridge](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/arokem/python-matlab-bridge?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 A python interface to call out to [Matlab(R)](http://mathworks.com). Original


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pymatbridge))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pymatbridge`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.