### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ On Linux, add the following line to your .bash_profile (or similar file for your
 
 On Windows, add the install location of libzmq.dll to the PATH environment variable.
 On Windows 7+, typing "environment variables" into the start menu will bring up the
-apporpriate Control Panel links.
+appropriate Control Panel links.
 
 #### Pointing the binary at the right place
 

--- a/pymatbridge/messenger/src/messenger.c
+++ b/pymatbridge/messenger/src/messenger.c
@@ -27,7 +27,7 @@ int initialize(char *socket_addr) {
     }
 }
 
-/* Check if the ZMQ server is intialized and print an error if not */
+/* Check if the ZMQ server is initialized and print an error if not */
 int checkInitialized(void) {
     if (!initialized) {
         mexErrMsgTxt("Error: ZMQ session not initialized");


### PR DESCRIPTION
There are small typos in:
- README.md
- pymatbridge/messenger/src/messenger.c

Fixes:
- Should read `initialized` rather than `intialized`.
- Should read `appropriate` rather than `apporpriate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md