### PR TITLE
Clean up messenger handling

### DIFF
--- a/pymatbridge/__init__.py
+++ b/pymatbridge/__init__.py
@@ -1,23 +1,12 @@
-# We first need to detect if we're being called as part of the setup.py
-# procedure itself in a reliable manner.
+from .pymatbridge import *
+from .version import __version__
+
 try:
-    __PYMATBRIDGE_SETUP__
-except NameError:
-    __PYMATBRIDGE_SETUP__ = False
-
-
-if __PYMATBRIDGE_SETUP__:
+    from .publish import *
+except ImportError:
     pass
-else:
-    from .pymatbridge import *
-    from .version import __version__
 
-    try:
-        from .publish import *
-    except ImportError:
-        pass
-
-    try:
-        from .matlab_magic import *
-    except ImportError:
-        pass
+try:
+    from .matlab_magic import *
+except ImportError:
+    pass

--- a/pymatbridge/pymatbridge.py
+++ b/pymatbridge/pymatbridge.py
@@ -36,6 +36,8 @@ from uuid import uuid4
 
 from numpy import ndarray, generic, float64, frombuffer, asfortranarray
 
+from pymatbridge.messenger.make import get_messenger_dir
+
 try:
     from scipy.sparse import spmatrix
 except ImportError:
@@ -110,6 +112,7 @@ def decode_pymat(dct):
     return dct
 
 MATLAB_FOLDER = '%s/matlab' % os.path.realpath(os.path.dirname(__file__))
+MESSENGER_FOLDER = '%s/messenger/%s' % (os.path.realpath(os.path.dirname(__file__)), get_messenger_dir())
 
 
 class _Session(object):
@@ -182,6 +185,7 @@ class _Session(object):
         # Matlab (e.g. isrow)
         return ["old_warning_state = warning('off','all');",
                 "addpath(genpath('%s'));" % MATLAB_FOLDER,
+                "addpath('%s');" % MESSENGER_FOLDER,
                 "warning(old_warning_state);",
                 "clear('old_warning_state');",
                 "cd('%s');" % os.getcwd()]

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,7 @@
 """Setup file for python-matlab-bridge"""
 
 import os
-import sys
 
-# BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
-# update it when the contents of directories change.
-if os.path.exists('MANIFEST'):
-    os.remove('MANIFEST')
-
-# we need some code from inside the package to build it. use the same hack as
-# numpy to selectively import even if we don't have dependencies installed
-if sys.version_info[0] >= 3:
-    import builtins
-else:
-    import __builtin__ as builtins
-builtins.__PYMATBRIDGE_SETUP__ = True
 try:
     from setuptools import setup
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,6 @@
 
 import os
 import sys
-import shutil
-import glob
-
 
 # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
 # update it when the contents of directories change.
@@ -19,13 +16,6 @@ if sys.version_info[0] >= 3:
 else:
     import __builtin__ as builtins
 builtins.__PYMATBRIDGE_SETUP__ = True
-# Find the messenger binary file(s) and copy it to /matlab folder.
-from pymatbridge.messenger.make import get_messenger_dir
-messenger_dir = get_messenger_dir()
-
-for f in glob.glob("./pymatbridge/messenger/%s/messenger.*" % messenger_dir):
-    shutil.copy(f, "./pymatbridge/matlab")
-
 try:
     from setuptools import setup
 except ImportError:


### PR DESCRIPTION
The main feature of this pull request is that it changes the messenger architecture to be detected at runtime instead of at setup. This makes it easier to package the project and makes it possible to remove some of the hacks from `setup.py`. It also fixes an issue with some users not having the correct messenger files installed (see e.g. https://github.com/arokem/python-matlab-bridge/issues/220#issuecomment-201360155).